### PR TITLE
Update entity email and description during UpsertManifest

### DIFF
--- a/queries.sql
+++ b/queries.sql
@@ -37,7 +37,9 @@ entity AS (
         type = ($1->'entity'->>'type')::entity_type,
         role = ($1->'entity'->>'role')::entity_role,
         name = $1->'entity'->>'name',
+        email = $1->'entity'->>'email',
         phone = $1->'entity'->>'phone',
+        description = $1->'entity'->>'description',
         webpage_url = $1->'entity'->'webpageUrl'->>'url',
         webpage_wellknown = $1->'entity'->'webpageUrl'->>'wellKnown',
         updated_at = NOW()


### PR DESCRIPTION
Noticed post a manifest update that the entity's email and description fields were not getting updated on the portal.

From my limited understanding of the code base, this PR  _should_ address the issue.