### PR TITLE
fix: format data for History

### DIFF
--- a/cmd/portal/init.go
+++ b/cmd/portal/init.go
@@ -307,6 +307,46 @@ func initHTTPOpt() common.HTTPOpt {
 	}
 }
 
+// formatNumber formats a number with thousands separators
+func formatNumber(n interface{}) string {
+	var num float64
+	switch v := n.(type) {
+	case int:
+		num = float64(v)
+	case int64:
+		num = float64(v)
+	case float64:
+		num = v
+	default:
+		return fmt.Sprintf("%v", n)
+	}
+
+	if num == 0 {
+		return "0"
+	}
+
+	isNegative := num < 0
+	if isNegative {
+		num = -num
+	}
+
+	result := fmt.Sprintf("%.0f", num)
+	var parts []string
+	for i := len(result); i > 0; i -= 3 {
+		start := i - 3
+		if start < 0 {
+			start = 0
+		}
+		parts = append([]string{result[start:i]}, parts...)
+	}
+
+	formatted := strings.Join(parts, ",")
+	if isNegative {
+		formatted = "-" + formatted
+	}
+	return formatted
+}
+
 func initSiteTemplates(dirPath string, wellKnownURI string) *template.Template {
 	// Create a new template set
 	tmpl := template.New("")
@@ -345,6 +385,9 @@ func initSiteTemplates(dirPath string, wellKnownURI string) *template.Template {
 
 			return urlStatus{Verified: false, Error: err}
 		},
+
+		// Format numbers with thousands separators
+		"formatNumber": formatNumber,
 	})
 
 	// Parse all HTML files that match the pattern

--- a/cmd/portal/init_test.go
+++ b/cmd/portal/init_test.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFormatNumber(t *testing.T) {
+	tests := []struct {
+		input    interface{}
+		expected string
+	}{
+		// Zero
+		{0, "0"},
+		{int64(0), "0"},
+		{float64(0), "0"},
+
+		// Small positive numbers
+		{1, "1"},
+		{99, "99"},
+		{999, "999"},
+
+		// Thousands
+		{1000, "1,000"},
+		{1234, "1,234"},
+		{12345, "12,345"},
+		{123456, "123,456"},
+		{1234567, "1,234,567"},
+
+		// Large numbers
+		{9876543, "9,876,543"},
+		{5555555, "5,555,555"},
+
+		// int64 types
+		{int64(1234567), "1,234,567"},
+		{int64(9876543), "9,876,543"},
+
+		// float64 types
+		{float64(1234567), "1,234,567"},
+		{float64(5555555), "5,555,555"},
+
+		// Negative numbers
+		{-1, "-1"},
+		{-1000, "-1,000"},
+		{-1234567, "-1,234,567"},
+		{float64(-2170474), "-2,170,474"},
+
+		// Edge cases
+		{10, "10"},
+		{100, "100"},
+		{10000, "10,000"},
+		{100000, "100,000"},
+		{1000000, "1,000,000"},
+	}
+
+	for _, tt := range tests {
+		result := formatNumber(tt.input)
+		assert.Equal(t, tt.expected, result, "formatNumber(%v) should equal %s", tt.input, tt.expected)
+	}
+}

--- a/site/funding.html
+++ b/site/funding.html
@@ -22,7 +22,7 @@
 						</td>
 						<td class="amount">
 							<span class="text-grey">{{ $p.Currency }}</span>
-							{{ $p.Amount }}
+							{{ formatNumber $p.Amount }}
 						</td>
 						<td>
 							<span class="text-grey">{{ title $p.Frequency }}</span>

--- a/site/history.html
+++ b/site/history.html
@@ -20,9 +20,9 @@
 				{{ range $p := .Data.Manifest.Funding.History }}
 					<tr id="history-{{ $p.Year }}">
 						<td>{{ $p.Year }}</td>
-						<td>{{ $p.Income }}</td>
-						<td>{{ $p.Expenses }}</td>
-						<td>{{ $p.Taxes }}</td>
+						<td>{{ formatNumber $p.Income }}</td>
+						<td>{{ formatNumber $p.Expenses }}</td>
+						<td>{{ formatNumber $p.Taxes }}</td>
 						<td>{{ $p.Currency }}</td>
 					</tr>
 					{{ if $p.Description }}


### PR DESCRIPTION
This should fix the number format in the History pages.

| Before | After |
|--------|--------|
| <img width="1244" height="373" alt="image" src="https://github.com/user-attachments/assets/ef8fcc7a-223a-486d-a1bd-2e96287f385f" /> | <img width="1276" height="366" alt="image" src="https://github.com/user-attachments/assets/abc4a7dd-10da-4695-b24c-5b082fc3f245" /> | 

disclosure: Since I'm new to Go, I used Claude to help with this. The tests should cover the fix, which I checked running everything locally.